### PR TITLE
feat: add terms form screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,7 +8,7 @@ import StorybookUIRoot from './storybook';
 import { Routes } from '@/feature/Routes';
 import useSplash from '@/hooks/useSplash';
 
-const isStorybookEnabled = Boolean(process.env.STORYBOOK_ENABLED);
+const isStorybookEnabled = process.env.STORYBOOK_ENABLED === 'true';
 
 const white = '#fff';
 

--- a/assets/icons/Line.tsx
+++ b/assets/icons/Line.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import Svg, { SvgProps, Path } from 'react-native-svg';
+
+const SvgComponent = (props: SvgProps) => (
+  <Svg
+    width={335}
+    height={2}
+    fill="none"
+    /* eslint-disable-next-line react/jsx-props-no-spreading */
+    {...props}
+  >
+    <Path d="M1 1h333" stroke="#E9EAEA" strokeLinecap="round" />
+  </Svg>
+);
+
+export default SvgComponent;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -47,6 +47,7 @@ const Button = ({
   <Pressable
     // eslint-disable-next-line react/jsx-props-no-spreading
     {...defaultProps}
+    disabled={disabled}
     style={[
       style,
       styles.container,

--- a/src/constants/screens.ts
+++ b/src/constants/screens.ts
@@ -1,0 +1,11 @@
+export enum Navigator {
+  AuthStack = 'AuthStack',
+}
+
+export enum Screen {
+  LoginScreen = 'LoginScreen',
+  TermsFormScreen = 'TermsFormScreen',
+  PersonalDataFormScreen = 'PersonalDataFormScreen',
+  UserProfileFormScreen = 'UserProfileFormScreen',
+  WelcomeScreen = 'WelcomeScreen',
+}

--- a/src/feature/GoogleLogin/index.tsx
+++ b/src/feature/GoogleLogin/index.tsx
@@ -8,6 +8,7 @@ import {
   GOOGLE_ANDROID_CLIENT_ID,
 } from 'react-native-dotenv';
 import { Button } from '@/components';
+import { TEXT_STYLE } from '@/constants/styles';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -53,7 +54,7 @@ const GoogleLogin = () => {
       }}
       backgroundColor="#ffffff"
     >
-      <Text style={styles.text}>Google로 시작하기</Text>
+      <Text style={[TEXT_STYLE.button16M, styles.text]}>Google로 시작하기</Text>
     </Button>
   );
 };

--- a/src/feature/Routes/AuthStack.tsx
+++ b/src/feature/Routes/AuthStack.tsx
@@ -1,0 +1,47 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import React from 'react';
+import { Screen } from '@/constants/screens';
+import LoginScreen, { LoginScreenParams } from '@/screens/LoginScreen';
+import {
+  PersonalDataFormScreen,
+  PersonalDataFormScreenParams,
+  TermsFormScreen,
+  TermsFormScreenParams,
+  UserProfileFormScreen,
+  UserProfileFormScreenParams,
+} from '@/screens/SignUpScreen';
+import WelcomeScreen, { WelcomeScreenParams } from '@/screens/WelcomeScreen';
+
+export type AuthStackParamsList = {
+  [Screen.LoginScreen]: LoginScreenParams;
+  [Screen.TermsFormScreen]: TermsFormScreenParams;
+  [Screen.PersonalDataFormScreen]: PersonalDataFormScreenParams;
+  [Screen.UserProfileFormScreen]: UserProfileFormScreenParams;
+  [Screen.WelcomeScreen]: WelcomeScreenParams;
+};
+
+const Stack = createStackNavigator<AuthStackParamsList>();
+
+const AuthStack = () => (
+  <Stack.Navigator
+    initialRouteName={Screen.LoginScreen}
+    screenOptions={{
+      headerShown: false,
+    }}
+  >
+    <Stack.Screen name={Screen.LoginScreen} component={LoginScreen} />
+    <Stack.Screen name={Screen.TermsFormScreen} component={TermsFormScreen} />
+    <Stack.Screen
+      name={Screen.PersonalDataFormScreen}
+      component={PersonalDataFormScreen}
+    />
+    <Stack.Screen
+      name={Screen.UserProfileFormScreen}
+      component={UserProfileFormScreen}
+    />
+    <Stack.Screen name={Screen.WelcomeScreen} component={WelcomeScreen} />
+  </Stack.Navigator>
+);
+
+export default AuthStack;

--- a/src/feature/Routes/index.tsx
+++ b/src/feature/Routes/index.tsx
@@ -1,26 +1,23 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import React from 'react';
-import { RootStackParamList, SignUpStep } from './types';
-import SignUpScreen from '@/screens/SignUpScreen';
-import WelcomeScreen from '@/screens/WelcomeScreen';
+import AuthStack, { AuthStackParamsList } from './AuthStack';
+import { Navigator } from '@/constants/screens';
 
-const Stack = createStackNavigator<RootStackParamList>();
+export type RootStackParamsList = {
+  [Navigator.AuthStack]: AuthStackParamsList;
+};
+
+const Stack = createStackNavigator<RootStackParamsList>();
 
 export const Routes = () => (
   <NavigationContainer>
     <Stack.Navigator
-      initialRouteName="SignUp"
       screenOptions={{
         headerShown: false,
       }}
     >
-      <Stack.Screen
-        name="SignUp"
-        component={SignUpScreen}
-        initialParams={{ process: SignUpStep.Terms }}
-      />
-      <Stack.Screen name="Welcome" component={WelcomeScreen} />
+      <Stack.Screen name={Navigator.AuthStack} component={AuthStack} />
     </Stack.Navigator>
   </NavigationContainer>
 );

--- a/src/feature/Routes/index.tsx
+++ b/src/feature/Routes/index.tsx
@@ -18,7 +18,7 @@ export const Routes = () => (
       <Stack.Screen
         name="SignUp"
         component={SignUpScreen}
-        initialParams={{ process: SignUpStep.PersonalData }}
+        initialParams={{ process: SignUpStep.Terms }}
       />
       <Stack.Screen name="Welcome" component={WelcomeScreen} />
     </Stack.Navigator>

--- a/src/feature/Routes/types.ts
+++ b/src/feature/Routes/types.ts
@@ -1,6 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack';
 
 export enum SignUpStep {
+  Terms = 'Terms',
   PersonalData = 'PersonalData',
   UserProfile = 'UserProfile',
 }

--- a/src/feature/TermsForm/TermItem.tsx
+++ b/src/feature/TermsForm/TermItem.tsx
@@ -1,0 +1,73 @@
+import type { ReactElement } from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import ArrowBack from '@/assets/icons/ArrowBack';
+import { Checkbox } from '@/components/Checkbox';
+import { COLOR, TEXT_STYLE } from '@/constants/styles';
+
+const styles = StyleSheet.create({
+  arrow: {
+    transform: [
+      {
+        rotate: '180deg',
+      },
+      {
+        translateX: 7,
+      },
+    ],
+  },
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    paddingVertical: 11,
+  },
+  contentContainer: {
+    flexDirection: 'row',
+    flex: 1,
+    justifyContent: 'space-between',
+    paddingLeft: 16,
+  },
+  textContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+});
+
+interface Props {
+  label: string;
+  isChecked: boolean;
+  prefix?: ReactElement;
+  isBold?: boolean;
+  onCheckboxPress?: () => void;
+  onLabelPress?: () => void;
+}
+
+const TermItem = ({
+  label,
+  isChecked,
+  prefix,
+  isBold = false,
+  onCheckboxPress,
+  onLabelPress,
+}: Props) => (
+  <View style={styles.container}>
+    <Checkbox isChecked={isChecked} onPress={onCheckboxPress} />
+    <Pressable
+      style={styles.contentContainer}
+      // `onLabelPress`가 따로 정의되어 있지 않으면 어느 영역을 누르든 `onCheckboxPress`가 동작해서
+      // 사용자가 좀 더 쉽게 누를 수 있도록 유도
+      onPress={onLabelPress ?? onCheckboxPress}
+    >
+      <View style={styles.textContainer}>
+        {prefix}
+        <Text style={isBold ? TEXT_STYLE.button16B : TEXT_STYLE.button16M}>
+          {label}
+        </Text>
+      </View>
+      {onLabelPress && (
+        <ArrowBack style={styles.arrow} color={COLOR.mono.gray3} />
+      )}
+    </Pressable>
+  </View>
+);
+
+export default TermItem;

--- a/src/feature/TermsForm/TermsForm.stories.tsx
+++ b/src/feature/TermsForm/TermsForm.stories.tsx
@@ -1,0 +1,8 @@
+import { action } from '@storybook/addon-actions';
+import { withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react-native';
+import TermsForm from '.';
+
+storiesOf('feature/TermsForm', module)
+  .addDecorator(withKnobs)
+  .add('default', () => <TermsForm onNextPress={action('onNextPress')} />);

--- a/src/feature/TermsForm/index.tsx
+++ b/src/feature/TermsForm/index.tsx
@@ -1,0 +1,128 @@
+import { useNavigation } from '@react-navigation/native';
+import { useState, useMemo } from 'react';
+import { Text } from 'react-native';
+import { SignUpScreenNavigationProp, SignUpStep } from '../Routes/types';
+import TermItem from './TermItem';
+import Line from '@/assets/icons/Line';
+import { UserInputLayout, Button } from '@/components';
+import { COLOR, TEXT_STYLE } from '@/constants/styles';
+import { useSignUpStore } from '@/states/signUpStore';
+
+const Prefix = ({ isRequired }: { isRequired: boolean }) => (
+  <Text
+    style={[
+      TEXT_STYLE.button16M,
+      {
+        color: isRequired ? COLOR.system.blue : COLOR.mono.gray3,
+      },
+    ]}
+  >
+    {isRequired ? '(필수) ' : '(선택) '}
+  </Text>
+);
+
+const TERMS = [
+  {
+    label: '서비스 이용약관 동의',
+    isRequired: true,
+  },
+  {
+    label: '개인정보 처리방침 동의',
+    isRequired: true,
+  },
+  {
+    label: '마케팅 정보 수신 동의',
+    isRequired: false,
+  },
+];
+
+interface Props {
+  onNextPress?: () => void;
+}
+
+const TermsForm = ({ onNextPress }: Props) => {
+  const { setIsMarketingAgreed } = useSignUpStore();
+  const navigation = useNavigation<SignUpScreenNavigationProp>();
+
+  const [checked, setChecked] = useState([false, false, false]);
+
+  const toggleChecked = (index: number) => {
+    setChecked((prev) => {
+      const newChecked = [...prev];
+      newChecked[index] = !newChecked[index];
+
+      return newChecked;
+    });
+  };
+
+  const isAllChecked = useMemo(() => {
+    let result = true;
+
+    checked.forEach((isChecked) => {
+      if (!isChecked) {
+        result = false;
+      }
+    });
+
+    return result;
+  }, [checked]);
+
+  const canGoNext = useMemo(() => {
+    let result = true;
+
+    checked.forEach((isChecked, index) => {
+      if (TERMS[index].isRequired && !isChecked) {
+        result = false;
+      }
+    });
+
+    return result;
+  }, [checked]);
+
+  const button = (
+    <Button
+      backgroundColor={COLOR.mono.gray7}
+      onPress={() => {
+        setIsMarketingAgreed(checked[2]);
+        navigation.navigate('SignUp', {
+          process: SignUpStep.PersonalData,
+        });
+      }}
+      disabled={!canGoNext}
+    >
+      <Text style={[TEXT_STYLE.button16M, { color: COLOR.mono.white }]}>
+        다음으로
+      </Text>
+    </Button>
+  );
+
+  return (
+    <UserInputLayout
+      infoMessage="가입약관을 확인해 주세요"
+      gap={8}
+      button={button}
+    >
+      <TermItem
+        label="약관 전체 동의"
+        isChecked={isAllChecked}
+        onCheckboxPress={() => {
+          setChecked((prev) => prev.map(() => !isAllChecked));
+        }}
+        isBold
+      />
+      <Line />
+      {TERMS.map((term, index) => (
+        <TermItem
+          key={term.label}
+          label={term.label}
+          isChecked={checked[index]}
+          onCheckboxPress={() => toggleChecked(index)}
+          onLabelPress={() => {}}
+          prefix={<Prefix isRequired={term.isRequired} />}
+        />
+      ))}
+    </UserInputLayout>
+  );
+};
+
+export default TermsForm;

--- a/src/feature/TermsForm/index.tsx
+++ b/src/feature/TermsForm/index.tsx
@@ -1,7 +1,5 @@
-import { useNavigation } from '@react-navigation/native';
 import { useState, useMemo } from 'react';
 import { Text } from 'react-native';
-import { SignUpScreenNavigationProp, SignUpStep } from '../Routes/types';
 import TermItem from './TermItem';
 import Line from '@/assets/icons/Line';
 import { UserInputLayout, Button } from '@/components';
@@ -42,7 +40,6 @@ interface Props {
 
 const TermsForm = ({ onNextPress }: Props) => {
   const { setIsMarketingAgreed } = useSignUpStore();
-  const navigation = useNavigation<SignUpScreenNavigationProp>();
 
   const [checked, setChecked] = useState([false, false, false]);
 
@@ -84,9 +81,7 @@ const TermsForm = ({ onNextPress }: Props) => {
       backgroundColor={COLOR.mono.gray7}
       onPress={() => {
         setIsMarketingAgreed(checked[2]);
-        navigation.navigate('SignUp', {
-          process: SignUpStep.PersonalData,
-        });
+        onNextPress?.();
       }}
       disabled={!canGoNext}
     >

--- a/src/screens/LoginScreen/index.tsx
+++ b/src/screens/LoginScreen/index.tsx
@@ -1,17 +1,34 @@
 /* eslint-disable react-native/no-raw-text */
+import {
+  CompositeNavigationProp,
+  useNavigation,
+} from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 import { ImageBackground, StyleSheet, Text, View } from 'react-native';
 import Logo from '@/assets/icons/Logo';
+import { Screen } from '@/constants/screens';
 import { COLOR } from '@/constants/styles/colors';
 import { TEXT_STYLE } from '@/constants/styles/textStyles';
 import GoogleLogin from '@/feature/GoogleLogin';
 import KakaoLogin from '@/feature/KakaoLogin';
+import { RootStackParamsList } from '@/feature/Routes';
+import { AuthStackParamsList } from '@/feature/Routes/AuthStack';
+
+export type LoginScreenParams = undefined;
+export type LoginScreenNP = CompositeNavigationProp<
+  StackNavigationProp<AuthStackParamsList, Screen.LoginScreen>,
+  StackNavigationProp<RootStackParamsList>
+>;
 
 const styles = StyleSheet.create({
   background: {
     flex: 1,
     position: 'relative',
     zIndex: 1,
+  },
+  button: {
+    marginBottom: 8,
   },
   container: {
     flex: 1,
@@ -38,26 +55,36 @@ const styles = StyleSheet.create({
   },
 });
 
-const LoginScreen = () => (
-  <View style={styles.container}>
-    <ImageBackground
-      // eslint-disable-next-line global-require
-      source={require('@/assets/images/login.png')}
-      resizeMode="cover"
-      style={styles.background}
-    >
-      <View style={styles.wrapLogo}>
-        <Logo />
-        <Text style={[styles.text, TEXT_STYLE.body16B]}>
-          당신의 작품을{'\n'}전시하세요
-        </Text>
-      </View>
-      <View style={styles.wrapButtons}>
-        <GoogleLogin />
-        <KakaoLogin />
-      </View>
-    </ImageBackground>
-  </View>
-);
+const LoginScreen = () => {
+  const navigation = useNavigation<LoginScreenNP>();
+
+  return (
+    <View style={styles.container}>
+      <ImageBackground
+        // eslint-disable-next-line global-require
+        source={require('@/assets/images/login.png')}
+        resizeMode="cover"
+        style={styles.background}
+      >
+        <View style={styles.wrapLogo}>
+          <Logo />
+          <Text style={[styles.text, TEXT_STYLE.body16B]}>
+            당신의 작품을{'\n'}전시하세요
+          </Text>
+        </View>
+        <View style={styles.wrapButtons}>
+          <View style={styles.button}>
+            <GoogleLogin />
+          </View>
+          <KakaoLogin
+            onSuccess={() => {
+              navigation.navigate(Screen.TermsFormScreen);
+            }}
+          />
+        </View>
+      </ImageBackground>
+    </View>
+  );
+};
 
 export default LoginScreen;

--- a/src/screens/SignUpScreen/PersonalDataFormScreen.tsx
+++ b/src/screens/SignUpScreen/PersonalDataFormScreen.tsx
@@ -1,0 +1,12 @@
+import SignUpTemplate from './SignUpTemplate';
+import PersonalDataForm from '@/feature/PersonalDataForm';
+
+export type PersonalDataFormScreenParams = undefined;
+
+const PersonalDataFormScreen = () => (
+  <SignUpTemplate>
+    <PersonalDataForm />
+  </SignUpTemplate>
+);
+
+export default PersonalDataFormScreen;

--- a/src/screens/SignUpScreen/SignUpTemplate.tsx
+++ b/src/screens/SignUpScreen/SignUpTemplate.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Header } from '@/components/Header';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
+
+interface Props {
+  children: ReactElement;
+}
+
+const SignUpTemplate = ({ children }: Props) => (
+  <SafeAreaView style={styles.container}>
+    <Header headerTitle="회원 가입" />
+    {children}
+  </SafeAreaView>
+);
+
+export default SignUpTemplate;

--- a/src/screens/SignUpScreen/TermsFormScreen.tsx
+++ b/src/screens/SignUpScreen/TermsFormScreen.tsx
@@ -1,0 +1,32 @@
+import {
+  CompositeNavigationProp,
+  useNavigation,
+} from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import SignUpTemplate from './SignUpTemplate';
+import { Screen } from '@/constants/screens';
+import { RootStackParamsList } from '@/feature/Routes';
+import { AuthStackParamsList } from '@/feature/Routes/AuthStack';
+import TermsForm from '@/feature/TermsForm';
+
+export type TermsFormScreenParams = undefined;
+export type TermsFormScreenNP = CompositeNavigationProp<
+  StackNavigationProp<AuthStackParamsList, Screen.TermsFormScreen>,
+  StackNavigationProp<RootStackParamsList>
+>;
+
+const TermsFormScreen = () => {
+  const navigation = useNavigation<TermsFormScreenNP>();
+
+  return (
+    <SignUpTemplate>
+      <TermsForm
+        onNextPress={() => {
+          navigation.navigate(Screen.PersonalDataFormScreen);
+        }}
+      />
+    </SignUpTemplate>
+  );
+};
+
+export default TermsFormScreen;

--- a/src/screens/SignUpScreen/UserProfileFormScreen.tsx
+++ b/src/screens/SignUpScreen/UserProfileFormScreen.tsx
@@ -1,0 +1,12 @@
+import SignUpTemplate from './SignUpTemplate';
+import UserProfileForm from '@/feature/UserProfileForm';
+
+export type UserProfileFormScreenParams = undefined;
+
+const UserProfileFormScreen = () => (
+  <SignUpTemplate>
+    <UserProfileForm />
+  </SignUpTemplate>
+);
+
+export default UserProfileFormScreen;

--- a/src/screens/SignUpScreen/index.tsx
+++ b/src/screens/SignUpScreen/index.tsx
@@ -5,6 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { SignUpScreenRouteProp, SignUpStep } from '../../feature/Routes/types';
 import { Header } from '@/components/Header';
 import PersonalDataForm from '@/feature/PersonalDataForm';
+import TermsForm from '@/feature/TermsForm';
 import UserProfileForm from '@/feature/UserProfileForm';
 
 const styles = StyleSheet.create({
@@ -14,6 +15,7 @@ const styles = StyleSheet.create({
 });
 
 const formComponentByStep = {
+  [SignUpStep.Terms]: <TermsForm />,
   [SignUpStep.PersonalData]: <PersonalDataForm />,
   [SignUpStep.UserProfile]: <UserProfileForm />,
 };

--- a/src/screens/SignUpScreen/index.tsx
+++ b/src/screens/SignUpScreen/index.tsx
@@ -1,35 +1,14 @@
-import { useRoute } from '@react-navigation/native';
-import React from 'react';
-import { StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { SignUpScreenRouteProp, SignUpStep } from '../../feature/Routes/types';
-import { Header } from '@/components/Header';
-import PersonalDataForm from '@/feature/PersonalDataForm';
-import TermsForm from '@/feature/TermsForm';
-import UserProfileForm from '@/feature/UserProfileForm';
+import PersonalDataFormScreen, {
+  PersonalDataFormScreenParams,
+} from './PersonalDataFormScreen';
+import TermsFormScreen, { TermsFormScreenParams } from './TermsFormScreen';
+import UserProfileFormScreen, {
+  UserProfileFormScreenParams,
+} from './UserProfileFormScreen';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
-
-const formComponentByStep = {
-  [SignUpStep.Terms]: <TermsForm />,
-  [SignUpStep.PersonalData]: <PersonalDataForm />,
-  [SignUpStep.UserProfile]: <UserProfileForm />,
+export { PersonalDataFormScreen, TermsFormScreen, UserProfileFormScreen };
+export type {
+  PersonalDataFormScreenParams,
+  TermsFormScreenParams,
+  UserProfileFormScreenParams,
 };
-
-const SignUpScreen = () => {
-  const {
-    params: { process },
-  } = useRoute<SignUpScreenRouteProp>();
-  return (
-    <SafeAreaView style={styles.container}>
-      <Header headerTitle="회원 가입" />
-      {formComponentByStep[process]}
-    </SafeAreaView>
-  );
-};
-
-export default SignUpScreen;

--- a/src/screens/WelcomeScreen/index.tsx
+++ b/src/screens/WelcomeScreen/index.tsx
@@ -7,6 +7,8 @@ import { Header } from '@/components/Header';
 import { COLOR } from '@/constants/styles/colors';
 import { TEXT_STYLE } from '@/constants/styles/textStyles';
 
+export type WelcomeScreenParams = undefined;
+
 const styles = StyleSheet.create({
   background: {
     flex: 1,

--- a/src/states/signUpStore.tsx
+++ b/src/states/signUpStore.tsx
@@ -9,6 +9,7 @@ interface UserInput<T> {
 }
 
 export interface SignUpValues {
+  isMarketingAgreed: boolean;
   userId: UserInput<string>;
   name: UserInput<string>;
   birthDay: UserInput<Date>;
@@ -18,6 +19,7 @@ export interface SignUpValues {
 }
 
 interface SignUpState extends SignUpValues {
+  setIsMarketingAgreed: (data: boolean) => void;
   setUserId: (data: UserInput<string>) => void;
   setName: (data: UserInput<string>) => void;
   setBirthDay: (data: UserInput<Date>) => void;
@@ -34,6 +36,9 @@ const createInitialUserInput = <T,>(value: T, isRequired: boolean = true) => ({
 });
 
 export const useSignUpStore = create<SignUpState>()((set) => ({
+  isMarketingAgreed: false,
+  setIsMarketingAgreed: (isMarketingAgreed) =>
+    set((state) => ({ ...state, isMarketingAgreed })),
   userId: createInitialUserInput(''),
   setUserId: (data: UserInput<string>) =>
     set((state) => ({ ...state, userId: data })),

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -7,12 +7,14 @@ function loadStories() {
   require('../src/components/Checkbox/Checkbox.stories');
   require('../src/components/FormInput/FormInput.stories');
   require('../src/feature/KakaoLogin/KakaoLogin.stories');
+  require('../src/feature/TermsForm/TermsForm.stories');
 }
 
 const stories = [
   '../src/components/Checkbox/Checkbox.stories',
   '../src/components/FormInput/FormInput.stories',
   '../src/feature/KakaoLogin/KakaoLogin.stories',
+  '../src/feature/TermsForm/TermsForm.stories',
 ];
 
 module.exports = {


### PR DESCRIPTION
약관 동의 화면을 추가합니다.

## 체크리스트

- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 작성한 코드에 대해 모두 이해하였는지 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈

- resolve #22 

## 설명
기존에 구현한 `Checkbox` 컴포넌트를 활용해 약관 동의 화면을 개발했습니다.
이 과정에서 기존에 만들었던 내비게이션 구조에 조금 이상함을 느껴서, 일단 제 머릿속에 있는 대로 최대한 바꿔보았어요! 한번 검토해 주시고, 다양한 의견 부탁드릴게요.
참고할 만한 자료 : https://reactnavigation.org/docs/nesting-navigators#best-practices-when-nesting