### PR TITLE
feat: add hash tag

### DIFF
--- a/assets/icons/Close.tsx
+++ b/assets/icons/Close.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import Svg, { SvgProps, G, Path, Defs, ClipPath } from 'react-native-svg';
+
+const SvgComponent = (props: SvgProps) => (
+  <Svg width={38} height={38} fill="none" viewBox="0 0 38 38" {...props}>
+    <G clipPath="url(#a)">
+      <Path
+        d="M26.66 11.34c-4.228-4.228-11.092-4.228-15.32 0-4.229 4.229-4.229 11.092 0 15.32 4.228 4.23 11.092 4.23 15.32 0 4.229-4.228 4.229-11.091 0-15.32Zm-4.596 12.256L19 20.532l-3.064 3.064-1.532-1.532L17.468 19l-3.064-3.064 1.532-1.532L19 17.468l3.064-3.064 1.532 1.532L20.532 19l3.064 3.064-1.532 1.532Z"
+        fill="currentColor"
+      />
+    </G>
+    <Defs>
+      <ClipPath id="a">
+        <Path
+          fill="currentColor"
+          transform="rotate(45 8.757 23.243)"
+          d="M0 0h26v26H0z"
+        />
+      </ClipPath>
+    </Defs>
+  </Svg>
+);
+
+export default SvgComponent;

--- a/src/components/FormInput/index.tsx
+++ b/src/components/FormInput/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { forwardRef, useState } from 'react';
+import { forwardRef, ReactNode, useState } from 'react';
 
 import {
   Platform,
@@ -28,6 +28,8 @@ interface Props extends TextInputProps {
   containerStyle?: ViewStyle;
   status?: FormInputStatus;
   message?: string;
+  leftElement?: ReactNode;
+  rightElement?: ReactNode;
 }
 
 const styles = StyleSheet.create({
@@ -87,6 +89,8 @@ export const FormInput = forwardRef<TextInput, Props>(
       label,
       style,
       containerStyle,
+      leftElement,
+      rightElement,
       ...textInputProps
     }: Props,
     ref,
@@ -95,6 +99,7 @@ export const FormInput = forwardRef<TextInput, Props>(
       {label && <Text style={[TEXT_STYLE.body14B, styles.label]}>{label}</Text>}
 
       <View style={styles.inputContainer}>
+        {leftElement}
         <TextInput
           placeholderTextColor={COLOR.mono.gray4}
           // spreading이 문제가 될 상황이 아니라고 판단
@@ -104,6 +109,7 @@ export const FormInput = forwardRef<TextInput, Props>(
           style={[TEXT_STYLE.body16R, styles.input, style]}
         />
         {status !== FormInputStatus.Initial && STATUS_ICON[status]}
+        {rightElement}
       </View>
 
       {status === FormInputStatus.Error && message && (

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,22 @@
+import { action } from '@storybook/addon-actions';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react-native';
+import { View, StyleSheet } from 'react-native';
+import { Tag } from '.';
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+});
+
+storiesOf('Tag', module)
+  .addDecorator(withKnobs)
+  .add('default', () => (
+    <View style={styles.container}>
+      <Tag
+        text={text('text', '해시태그')}
+        onDeletePress={action('onDeletePress')}
+      />
+    </View>
+  ));

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,0 +1,37 @@
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import CloseIcon from '@/assets/icons/Close';
+import { COLOR, TEXT_STYLE } from '@/constants/styles';
+
+interface Props {
+  text: string;
+  onDeletePress?: () => void;
+}
+
+const styles = StyleSheet.create({
+  closeButton: {
+    height: 26,
+    marginLeft: 4,
+    width: 26,
+  },
+  container: {
+    alignItems: 'center',
+    backgroundColor: COLOR.mono.gray7,
+    borderRadius: 21,
+    flexDirection: 'row',
+    height: 26,
+  },
+  text: {
+    color: COLOR.mono.white,
+  },
+});
+
+export const Tag = ({ text, onDeletePress }: Props) => (
+  <View style={styles.container}>
+    <Text style={[styles.text, TEXT_STYLE.body16R]}>
+      {'  '}#{text}
+    </Text>
+    <Pressable style={styles.closeButton} onPress={onDeletePress}>
+      <CloseIcon width={26} height={26} color={COLOR.mono.white} />
+    </Pressable>
+  </View>
+);

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,9 +1,10 @@
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { View, Text, Pressable, StyleSheet, ViewStyle } from 'react-native';
 import CloseIcon from '@/assets/icons/Close';
 import { COLOR, TEXT_STYLE } from '@/constants/styles';
 
 interface Props {
   text: string;
+  style?: ViewStyle;
   onDeletePress?: () => void;
 }
 
@@ -25,8 +26,8 @@ const styles = StyleSheet.create({
   },
 });
 
-export const Tag = ({ text, onDeletePress }: Props) => (
-  <View style={styles.container}>
+export const Tag = ({ text, style, onDeletePress }: Props) => (
+  <View style={[styles.container, style]}>
     <Text style={[styles.text, TEXT_STYLE.body16R]}>
       {'  '}#{text}
     </Text>

--- a/src/constants/screens.ts
+++ b/src/constants/screens.ts
@@ -17,4 +17,5 @@ export enum Screen {
   GroupFeedScreen = 'GroupFeedScreen',
   NotificationScreen = 'NotificationScreen',
   ProfileScreen = 'ProfileScreen',
+  AddHashtagScreen = 'AddHashtagScreen',
 }

--- a/src/feature/PictureDescriptionList/PictureDescriptionItem.tsx
+++ b/src/feature/PictureDescriptionList/PictureDescriptionItem.tsx
@@ -21,6 +21,10 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     width: '100%',
   },
+  contentContainer: {
+    flex: 1,
+    paddingLeft: 20,
+  },
   count: {
     color: COLOR.mono.gray4,
     marginTop: 37,
@@ -36,37 +40,58 @@ const styles = StyleSheet.create({
     marginLeft: 12,
     width: 40,
   },
+  tag: {
+    color: COLOR.mono.gray5,
+    marginRight: 4,
+  },
+  tagsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 8,
+  },
   textInput: {
     flex: 1,
     height: '100%',
     lineHeight: 24,
-    paddingLeft: 20,
     textAlignVertical: 'top',
   },
 });
 
 export interface PictureDescriptionItemProps extends PictureInfo {
   onChangeDescription?: (Description: string) => void;
+  onHashtagPress?: () => void;
 }
 
 const PictureDescriptionItem = ({
   imageUri,
   description,
+  hashtags,
   onChangeDescription,
+  onHashtagPress,
 }: PictureDescriptionItemProps) => (
   <View style={styles.container}>
-    <Image source={{ uri: imageUri }} style={styles.img} resizeMode="center" />
-    <TextInput
-      multiline
-      numberOfLines={4}
-      onChangeText={onChangeDescription}
-      style={[styles.textInput, TEXT_STYLE.body14R]}
-      placeholder={'작품의 설명을 입력해 주세요.\n(총 50자)'}
-      maxLength={50}
-      value={description}
-    />
+    <Image source={{ uri: imageUri }} style={styles.img} resizeMode="cover" />
+    <View style={styles.contentContainer}>
+      <TextInput
+        multiline
+        numberOfLines={4}
+        onChangeText={onChangeDescription}
+        style={[styles.textInput, TEXT_STYLE.body14R]}
+        placeholder={'작품의 설명을 입력해 주세요.\n(총 50자)'}
+        maxLength={50}
+        value={description}
+      />
+      <View style={styles.tagsContainer}>
+        {hashtags.map((tag) => (
+          <Text key={tag} style={[TEXT_STYLE.body14R, styles.tag]}>
+            #{tag}
+          </Text>
+        ))}
+      </View>
+    </View>
+
     <View style={styles.sideInfo}>
-      <Pressable>
+      <Pressable onPress={onHashtagPress}>
         <Hashtag />
       </Pressable>
       {description.length > 0 && (

--- a/src/feature/PictureDescriptionList/index.tsx
+++ b/src/feature/PictureDescriptionList/index.tsx
@@ -1,19 +1,34 @@
-import { FlatList } from 'react-native';
+import { FlatList, StyleSheet } from 'react-native';
 import PictureDescriptionItem from './PictureDescriptionItem';
 import { useCreateFloorStore } from '@/states/createFloorStore';
 
-const PictureDescriptionList = () => {
+interface Props {
+  onHashtagPress: (id: number) => void;
+}
+
+const styles = StyleSheet.create({
+  flatList: {
+    height: '100%',
+  },
+});
+
+const PictureDescriptionList = ({ onHashtagPress }: Props) => {
   const { pictures, onChangeDescriptionByIdx } = useCreateFloorStore();
   return (
     <FlatList
       data={pictures}
       keyExtractor={(_, index) => `picture_${index}`}
-      renderItem={({ item: { description, imageUri }, index }) => (
+      renderItem={({ item, index }) => (
         <PictureDescriptionItem
-          {...{ description, imageUri }}
+          {...item}
           onChangeDescription={onChangeDescriptionByIdx(index)}
+          onHashtagPress={() => {
+            // TODO: DB 상의 id로 바꿔야 함
+            onHashtagPress(index);
+          }}
         />
       )}
+      style={styles.flatList}
     />
   );
 };

--- a/src/feature/Routes/FloorStack.tsx
+++ b/src/feature/Routes/FloorStack.tsx
@@ -1,4 +1,3 @@
-import { NavigatorScreenParams } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { Screen } from '@/constants/screens';
 import {
@@ -6,11 +5,14 @@ import {
   AddPictureScreenParams,
   PictureDescriptionScreen,
   PictureDescriptionScreenParams,
+  AddHashtagScreen,
+  AddHashtagScreenParams,
 } from '@/screens/CreateFloorScreen';
 
 export type FloorStackParamsList = {
-  [Screen.AddPictureScreen]: NavigatorScreenParams<AddPictureScreenParams>;
-  [Screen.PictureDescriptionScreen]: NavigatorScreenParams<PictureDescriptionScreenParams>;
+  [Screen.AddPictureScreen]: AddPictureScreenParams;
+  [Screen.PictureDescriptionScreen]: PictureDescriptionScreenParams;
+  [Screen.AddHashtagScreen]: AddHashtagScreenParams;
 };
 
 const Stack = createStackNavigator<FloorStackParamsList>();
@@ -27,6 +29,7 @@ const FloorStack = () => (
       name={Screen.PictureDescriptionScreen}
       component={PictureDescriptionScreen}
     />
+    <Stack.Screen name={Screen.AddHashtagScreen} component={AddHashtagScreen} />
   </Stack.Navigator>
 );
 

--- a/src/feature/Routes/index.tsx
+++ b/src/feature/Routes/index.tsx
@@ -22,7 +22,7 @@ const Stack = createStackNavigator<RootStackParamsList>();
 
 export const Routes = () => {
   const { accessToken } = useAuthStore();
-      
+
   return (
     <NavigationContainer>
       <Stack.Navigator
@@ -30,13 +30,13 @@ export const Routes = () => {
           headerShown: false,
         }}
       >
+        <Stack.Screen name={Navigator.FloorStack} component={FloorStack} />
         {accessToken ? (
           <Stack.Screen name={Navigator.MainTab} component={MainTabNavigator} />
         ) : (
           <Stack.Screen name={Navigator.AuthStack} component={AuthStack} />
         )}
         <Stack.Screen name={Screen.WelcomeScreen} component={WelcomeScreen} />
-        <Stack.Screen name={Navigator.FloorStack} component={FloorStack} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/feature/Routes/index.tsx
+++ b/src/feature/Routes/index.tsx
@@ -30,13 +30,13 @@ export const Routes = () => {
           headerShown: false,
         }}
       >
-        <Stack.Screen name={Navigator.FloorStack} component={FloorStack} />
         {accessToken ? (
           <Stack.Screen name={Navigator.MainTab} component={MainTabNavigator} />
         ) : (
           <Stack.Screen name={Navigator.AuthStack} component={AuthStack} />
         )}
         <Stack.Screen name={Screen.WelcomeScreen} component={WelcomeScreen} />
+        <Stack.Screen name={Navigator.FloorStack} component={FloorStack} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screens/CreateFloorScreen/AddHashtagScreen.tsx
+++ b/src/screens/CreateFloorScreen/AddHashtagScreen.tsx
@@ -1,0 +1,149 @@
+import {
+  CompositeNavigationProp,
+  RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { useCallback, useState } from 'react';
+import { View, StyleSheet, Text, Pressable } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import shallow from 'zustand/shallow';
+import { Header, FormInput } from '@/components';
+import { Tag } from '@/components/Tag';
+import { Screen } from '@/constants/screens';
+import { COLOR, TEXT_STYLE } from '@/constants/styles';
+import { RootStackParamsList } from '@/feature/Routes';
+import { FloorStackParamsList } from '@/feature/Routes/FloorStack';
+import { useCreateFloorStore } from '@/states/createFloorStore';
+
+export type AddHashtagScreenParams = {
+  id: number;
+};
+export type AddHashtagScreenNP = CompositeNavigationProp<
+  StackNavigationProp<FloorStackParamsList, Screen.AddHashtagScreen>,
+  StackNavigationProp<RootStackParamsList>
+>;
+export type AddHashtagScreenRP = RouteProp<
+  FloorStackParamsList,
+  Screen.AddHashtagScreen
+>;
+
+const styles = StyleSheet.create({
+  confirmText: {
+    color: COLOR.system.blue,
+  },
+  container: {
+    flex: 1,
+    marginTop: 24,
+    paddingHorizontal: 20,
+  },
+  prefix: {
+    marginRight: 4,
+  },
+  safeAreaView: {
+    backgroundColor: COLOR.mono.white,
+    flex: 1,
+  },
+  tag: {
+    marginBottom: 4,
+    marginRight: 4,
+  },
+  tagsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 8,
+  },
+});
+
+const Prefix = () => <Text style={[styles.prefix, TEXT_STYLE.body16R]}>#</Text>;
+
+const AddHashtagScreen = () => {
+  const route = useRoute<AddHashtagScreenRP>();
+  const navigation = useNavigation<AddHashtagScreenNP>();
+
+  const [inputText, setInputText] = useState('');
+
+  const { hashtags, setHashtag } = useCreateFloorStore(
+    (state) => ({
+      hashtags: state.pictures[route.params.id].hashtags,
+      setHashtag: state.setHashtag,
+    }),
+    shallow,
+  );
+
+  const addHashtag = useCallback(
+    (newTag: string) => {
+      if (hashtags.findIndex((v) => v === newTag) === -1) {
+        setHashtag(route.params.id, [...hashtags, newTag]);
+      } else {
+        setInputText('');
+      }
+    },
+    [route.params.id, hashtags, setHashtag],
+  );
+
+  const deleteHashtag = useCallback(
+    (index: number) => {
+      setHashtag(
+        route.params.id,
+        hashtags.slice(0, index).concat(hashtags.slice(index + 1)),
+      );
+    },
+    [route.params.id, hashtags, setHashtag],
+  );
+
+  const ConfirmButton = useCallback(
+    () => (
+      <Pressable onPress={navigation.goBack}>
+        <Text style={[styles.confirmText, TEXT_STYLE.body16M]}>완료</Text>
+      </Pressable>
+    ),
+    [navigation.goBack],
+  );
+
+  const AddButton = useCallback(
+    () => (
+      <Pressable
+        onPress={() => {
+          setInputText((prev) => {
+            addHashtag(prev);
+            return '';
+          });
+        }}
+      >
+        <Text style={TEXT_STYLE.body16R}>추가</Text>
+      </Pressable>
+    ),
+    [addHashtag],
+  );
+
+  return (
+    <SafeAreaView style={styles.safeAreaView}>
+      <Header headerTitle="사진 태그 추가" headerRight={ConfirmButton} />
+      <View style={styles.container}>
+        <FormInput
+          leftElement={<Prefix />}
+          rightElement={<AddButton />}
+          placeholder="태그를 입력해 주세요. (최대 5개)"
+          value={inputText}
+          onChangeText={setInputText}
+        />
+        <View style={styles.tagsContainer}>
+          {hashtags.map((tag, index) => (
+            <Tag
+              key={tag}
+              text={tag}
+              onDeletePress={() => {
+                deleteHashtag(index);
+              }}
+              style={styles.tag}
+            />
+          ))}
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default AddHashtagScreen;

--- a/src/screens/CreateFloorScreen/PictureDescriptionScreen.tsx
+++ b/src/screens/CreateFloorScreen/PictureDescriptionScreen.tsx
@@ -1,9 +1,18 @@
-import { Pressable, StyleSheet, Text } from 'react-native';
+import {
+  CompositeNavigationProp,
+  useNavigation,
+} from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { Keyboard, Pressable, StyleSheet, Text } from 'react-native';
+import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WithKeyboardAvoidingView } from '@/components';
 import { Header } from '@/components/Header';
+import { Screen } from '@/constants/screens';
 import { COLOR, TEXT_STYLE } from '@/constants/styles';
 import PictureDescriptionList from '@/feature/PictureDescriptionList';
+import { RootStackParamsList } from '@/feature/Routes';
+import { FloorStackParamsList } from '@/feature/Routes/FloorStack';
 
 const styles = StyleSheet.create({
   buttonText: {
@@ -17,8 +26,14 @@ const styles = StyleSheet.create({
 });
 
 export type PictureDescriptionScreenParams = undefined;
+export type PictureDescriptionScreenNP = CompositeNavigationProp<
+  StackNavigationProp<FloorStackParamsList, Screen.AddHashtagScreen>,
+  StackNavigationProp<RootStackParamsList>
+>;
 
 const PictureDescriptionScreen = () => {
+  const navigation = useNavigation<PictureDescriptionScreenNP>();
+
   const headerRight = () => (
     <Pressable>
       <Text style={[styles.buttonText, TEXT_STYLE.body16M]}>다음</Text>
@@ -27,8 +42,15 @@ const PictureDescriptionScreen = () => {
   return (
     <SafeAreaView style={styles.container}>
       <Header headerTitle="플로어 추가" headerRight={headerRight} />
+
       <WithKeyboardAvoidingView>
-        <PictureDescriptionList />
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <PictureDescriptionList
+            onHashtagPress={(id: number) => {
+              navigation.navigate(Screen.AddHashtagScreen, { id });
+            }}
+          />
+        </TouchableWithoutFeedback>
       </WithKeyboardAvoidingView>
     </SafeAreaView>
   );

--- a/src/screens/CreateFloorScreen/index.tsx
+++ b/src/screens/CreateFloorScreen/index.tsx
@@ -1,7 +1,12 @@
+import AddHashtagScreen, { AddHashtagScreenParams } from './AddHashtagScreen';
 import AddPictureScreen, { AddPictureScreenParams } from './AddPictureScreen';
 import PictureDescriptionScreen, {
   PictureDescriptionScreenParams,
 } from './PictureDescriptionScreen';
 
-export { AddPictureScreen, PictureDescriptionScreen };
-export type { AddPictureScreenParams, PictureDescriptionScreenParams };
+export { AddPictureScreen, PictureDescriptionScreen, AddHashtagScreen };
+export type {
+  AddPictureScreenParams,
+  PictureDescriptionScreenParams,
+  AddHashtagScreenParams,
+};

--- a/src/states/createFloorStore.tsx
+++ b/src/states/createFloorStore.tsx
@@ -3,17 +3,20 @@ import create from 'zustand';
 export interface PictureInfo {
   imageUri: string;
   description: string;
+  hashtags: string[];
 }
 
 interface CreateFloorStore {
   pictures: PictureInfo[];
   createPicturesByImageUris: (imageUrls: string[]) => void;
   onChangeDescriptionByIdx: (idx: number) => (description: string) => void;
+  setHashtag: (imageIndex: number, hashtags: string[]) => void;
 }
 
 const createDefaultPictureInfo = (imageUri: string): PictureInfo => ({
   imageUri,
   description: '',
+  hashtags: [],
 });
 
 export const useCreateFloorStore = create<CreateFloorStore>()((set) => ({
@@ -32,6 +35,17 @@ export const useCreateFloorStore = create<CreateFloorStore>()((set) => ({
         { ...state.pictures[idx], description },
         ...state.pictures.slice(idx + 1),
       ],
+    }));
+  },
+  setHashtag: (imageIndex, hashtags) => {
+    set((state) => ({
+      ...state,
+      pictures: state.pictures.map((picture, index) => {
+        if (index === imageIndex) {
+          return { ...picture, hashtags };
+        }
+        return picture;
+      }),
     }));
   },
 }));

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -6,6 +6,7 @@
 function loadStories() {
   require('../src/components/Checkbox/Checkbox.stories');
   require('../src/components/FormInput/FormInput.stories');
+  require('../src/components/Tag/Tag.stories');
   require('../src/feature/AppleLogin/AppleLogin.stories');
   require('../src/feature/KakaoLogin/KakaoLogin.stories');
   require('../src/feature/TermsForm/TermsForm.stories');
@@ -14,6 +15,7 @@ function loadStories() {
 const stories = [
   '../src/components/Checkbox/Checkbox.stories',
   '../src/components/FormInput/FormInput.stories',
+  '../src/components/Tag/Tag.stories',
   '../src/feature/AppleLogin/AppleLogin.stories',
   '../src/feature/KakaoLogin/KakaoLogin.stories',
   '../src/feature/TermsForm/TermsForm.stories',


### PR DESCRIPTION
해시태그 컴포넌트와 해시태그 추가 화면을 구현했습니다.

## 체크리스트

- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 작성한 코드에 대해 모두 이해하였는지 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈

- resolve #32 

## 설명

해시태그 컴포넌트와 해시태그 추가 화면을 구현했습니다.
`AddHashtagScreen`에서도 `TouchableWithoutFeedback`에 `Keyboard.dismiss`를 걸고 싶었는데, 이걸 걸면 자꾸 레이아웃이 망가지는 문제가 있어서 보류했습니다.

| `AddHashtagScreen` | `PictureDescriptionScreen` |
| :--: | :--: |
| <img width="300" alt="스크린샷 2022-10-16 오전 4 20 26" src="https://user-images.githubusercontent.com/28603140/196004303-174b3c9b-ed60-41b2-a525-3cafcfe3e8e9.png"> | <img width="300" alt="스크린샷 2022-10-16 오전 4 20 39" src="https://user-images.githubusercontent.com/28603140/196004309-06a2559e-8480-4a63-9769-f4649b68a875.png"> |